### PR TITLE
Fix renote display size

### DIFF
--- a/packages/frontend-embed/src/components/EmNote.vue
+++ b/packages/frontend-embed/src/components/EmNote.vue
@@ -442,10 +442,11 @@ const isDeleted = ref(false);
 }
 
 .quoteNote {
-	padding: 16px;
-	border: dashed 1px var(--MI_THEME-renote);
-	border-radius: 8px;
-	overflow: clip;
+        padding: 16px;
+        border: dashed 1px var(--MI_THEME-renote);
+        border-radius: 8px;
+        overflow: clip;
+        font-size: inherit;
 }
 
 .channel {
@@ -591,9 +592,10 @@ const isDeleted = ref(false);
 }
 
 @container (max-width: 250px) {
-	.quoteNote {
-		padding: 12px;
-	}
+        .quoteNote {
+                padding: 12px;
+                font-size: inherit;
+        }
 }
 
 .reactionOmitted {

--- a/packages/frontend-embed/src/components/EmNoteDetailed.vue
+++ b/packages/frontend-embed/src/components/EmNoteDetailed.vue
@@ -349,10 +349,11 @@ const collapsed = ref(appearNote.value.cw == null && isLong);
 }
 
 .quoteNote {
-	padding: 16px;
-	border: dashed 1px var(--MI_THEME-renote);
-	border-radius: 8px;
-	overflow: clip;
+        padding: 16px;
+        border: dashed 1px var(--MI_THEME-renote);
+        border-radius: 8px;
+        overflow: clip;
+        font-size: inherit;
 }
 
 .channel {

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -978,10 +978,11 @@ function emitUpdReaction(emoji: string, delta: number) {
 }
 
 .quoteNote {
-	padding: 16px;
-	border: dashed 1px var(--MI_THEME-renote);
-	border-radius: 8px;
-	overflow: clip;
+        padding: 16px;
+        border: dashed 1px var(--MI_THEME-renote);
+        border-radius: 8px;
+        overflow: clip;
+        font-size: inherit;
 }
 
 .channel {
@@ -1124,9 +1125,10 @@ function emitUpdReaction(emoji: string, delta: number) {
 }
 
 @container (max-width: 250px) {
-	.quoteNote {
-		padding: 12px;
-	}
+        .quoteNote {
+                padding: 12px;
+                font-size: inherit;
+        }
 }
 
 .muted {

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -806,10 +806,11 @@ function loadConversation() {
 }
 
 .quoteNote {
-	padding: 16px;
-	border: dashed 1px var(--MI_THEME-renote);
-	border-radius: 8px;
-	overflow: clip;
+        padding: 16px;
+        border: dashed 1px var(--MI_THEME-renote);
+        border-radius: 8px;
+        overflow: clip;
+        font-size: inherit;
 }
 
 .channel {


### PR DESCRIPTION
## Summary
- adjust `.quoteNote` style to inherit font size so renoted posts show at the same scale as regular notes

## Testing
- `pnpm test` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.11.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68463ed7c820832aa9325aa04366cddf